### PR TITLE
Update LlamaIndex Notebook for API Migration

### DIFF
--- a/notebooks/using-vectara-with-llamaindex.ipynb
+++ b/notebooks/using-vectara-with-llamaindex.ipynb
@@ -15,7 +15,9 @@
    "source": [
     "# Vectara and LlamaIndex\n",
     "\n",
-    "In this notebook we are going to show how to use Vectara with LlamaIndex."
+    "In this notebook we are going to show how to use Vectara with LlamaIndex.\n",
+    "\n",
+    "Please note: We have updated our integration with LlamaIndex (llama-index-indices-managed-vectara version >= 0.4.0) to use our API v2, so some of the parameters and credentials required for our integration have changed. The latest changes are reflected in this example notebook."
    ]
   },
   {
@@ -76,7 +78,7 @@
     "\n",
     "To get started with Vectara, [sign up](https://console.vectara.com/signup?utm_source=vectara&utm_medium=signup&utm_term=DevRel&utm_content=example-notebooks&utm_campaign=vectara-signup-DevRel-example-notebooks) (if you haven't already) and follow our [quickstart](https://docs.vectara.com/docs/quickstart) guide to create a corpus and an API key. \n",
     "\n",
-    "Once you have these, you can provide them as environment variables, which will be used by the LlamaIndex code later on:"
+    "Once you have these, you can provide them as environment variables or explicitly define them in the code cell below. These will be used by the LlamaIndex code later on to connect the index to your Vectara corpus:"
    ]
   },
   {
@@ -90,8 +92,7 @@
     "\n",
     "import os\n",
     "# os.environ['VECTARA_API_KEY'] = \"<YOUR_VECTARA_API_KEY>\"\n",
-    "# os.environ['VECTARA_CORPUS_ID'] = \"<YOUR_VECTARA_CORPUS_ID>\"\n",
-    "# os.environ['VECTARA_CUSTOMER_ID'] = \"<YOUR_VECTARA_CUSTOMER_ID>\""
+    "# os.environ['VECTARA_CORPUS_KEY'] = \"<YOUR_VECTARA_CORPUS_KEY>\""
    ]
   },
   {
@@ -133,7 +134,7 @@
     {
      "data": {
       "text/plain": [
-       "['http://arxiv.org/abs/2402.14776v2',\n",
+       "['http://arxiv.org/abs/2402.14776v3',\n",
        " 'http://arxiv.org/abs/2007.01852v2',\n",
        " 'http://arxiv.org/abs/1910.13291v1',\n",
        " 'http://arxiv.org/abs/2104.06719v1',\n",
@@ -162,7 +163,15 @@
    "execution_count": 4,
    "id": "c154dd4b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File temp/1909.03104v2.Efficient_Sentence_Embedding_using_Discrete_Cosine_Transform.pdf failed to load with error HTTP Error 404: Not Found\n"
+     ]
+    }
+   ],
    "source": [
     "import shutil\n",
     "from llama_index.indices.managed.vectara import VectaraIndex\n",
@@ -198,7 +207,7 @@
    "metadata": {},
    "source": [
     "Two important things to note here:\n",
-    "1. Vectara processes each file uploaded on the backend, and performs appropriate chunking. So you don't need to apply any local processing, or choose a chunking strategy. \n",
+    "1. Vectara processes each file uploaded on the backend, and performs appropriate chunking. So you don't need to apply any local processing, or choose a chunking strategy. If you would like to have more control over how these documents are indexed, such as specifying the maximum number of characters per chunk, you can add the `chunking_strategy` argument to the `insert_file()` function used in the above cell.\n",
     "2. We have used the fields `url`, `title`, `author`, and `published` as metadata fields (for simplicity, author is the first author if there are multiple). You will need to make sure those fields are defined in your Vectara corpus as [filterable metadata fields](https://docs.vectara.com/docs/learn/metadata-search-filtering/filter-overview) to ensure we can filter by them in query time.\n",
     "\n",
     "So that's it for upload. "
@@ -235,9 +244,9 @@
      "text": [
       "Based on the provided sources, here is a summary that answers the query \"What is sentence embedding?\":\n",
       "\n",
-      "Sentence embedding is a form of word or sentence representation that maps text data into vectors, which can be a set of real numbers (a vector) [1]. It is a way to represent words or sentences in a text that encodes the meaning of the word or the sentence in n-dimensional space [1]. The goal of sentence embedding is to make the embeddings of two sentences that are similar to get closer in this vector space [2]. This is achieved by training models such as SimCSE, BERT, or RoBERTa, which input a sentence and output a vector representation of it [3]. The vector representation captures the meaning of the sentence, and sentences that are similar in meaning will have vectors that are closer together in the vector space [1][2].\n",
+      "Sentence embedding is a technique that represents words or sentences in a text in a n-dimensional space, encoding the meaning of the word or sentence [2]. It is a vital technique in practical applications, enabling the extraction of parallel data from extensive web corpora across two languages, enhancing the training of high-quality machine translation and multilingual language models [1]. Sentence embedding is also instrumental for zero-shot cross-lingual retrieval, an essential method for enabling cross-lingual searches on e-commerce platforms like Amazon [1]. In the context of machine learning, sentence embedding is a form of word or sentence representation by learned representations that prepare texts in an understandable format for a machine [2].\n",
       "\n",
-      "Sources: [1], [2], [3]\n"
+      "Sources: [1], [2]\n"
      ]
     }
    ],
@@ -270,10 +279,10 @@
     {
      "data": {
       "text/plain": [
-       "[(0, 'http://arxiv.org/pdf/2206.02690v3'),\n",
-       " (1, 'http://arxiv.org/pdf/1910.13291v1'),\n",
+       "[(0, 'http://arxiv.org/pdf/2205.15744v2'),\n",
+       " (1, 'http://arxiv.org/pdf/2206.02690v3'),\n",
        " (2, 'http://arxiv.org/pdf/2305.03010v1'),\n",
-       " (3, 'http://arxiv.org/pdf/1904.05542v1'),\n",
+       " (3, 'http://arxiv.org/pdf/2305.03010v1'),\n",
        " (4, 'http://arxiv.org/pdf/1904.05542v1'),\n",
        " (5, 'http://arxiv.org/pdf/1904.05542v1'),\n",
        " (6, 'http://arxiv.org/pdf/1904.05542v1'),\n",
@@ -303,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "abd30027-d975-4440-a1c2-66d1bd30bc29",
    "metadata": {},
    "outputs": [
@@ -313,13 +322,13 @@
      "text": [
       "Based on the provided sources, here is a summary that answers the query \"What is sentence embedding?\":\n",
       "\n",
-      "Sentence embedding is a form of word or sentence representation that maps text data into vectors, which can be a set of real numbers (a vector) [1]. It is a way to represent words or sentences in a text that encodes the meaning of the word or the sentence in n-dimensional space [1]. The goal of sentence embedding is to make the embeddings of two sentences that are similar to get closer in this vector space [2]. This is achieved by training models such as SimCSE, BERT, or RoBERTa, which input sentence representations and output sentence embeddings [3].\n",
+      "Sentence embedding is a technique that represents words or sentences in a text in a way that encodes their meaning in n-dimensional space [2]. It is a vital technique in practical applications, enabling the extraction of parallel data from extensive web corpora across two languages, enhancing the training of high-quality machine translation and multilingual language models [1]. Sentence embedding is also instrumental for zero-shot cross-lingual retrieval, an essential method for enabling cross-lingual searches on e-commerce platforms like Amazon [1].\n",
       "\n",
-      "In the context of natural language processing, sentence embedding is used to capture the meaning of a sentence and is used in tasks such as multiple choice question answering, next sentence prediction, and paraphrase identification [2]. It is also used in models such as LSTM, SDAE, and NMT, which use sentence embeddings as input representations [4].\n",
+      "In the context of machine learning, sentence embedding is a form of word or sentence representation by learned representations that prepare texts in an understandable format for a machine [2]. It maps text data into vectors that can be a set of real numbers (a vector), where words or sentences that are closer in the vector space are more similar [2].\n",
       "\n",
-      "Overall, sentence embedding is a way to represent the meaning of a sentence in a machine-understandable format, which is essential for various natural language processing tasks.\n",
+      "There are different approaches to sentence embedding, including traditional word embedding, static word embedding, contextualized word embedding, and two-sentence embeddings approach, with non-parameterized and parameterized models [2].\n",
       "\n",
-      "Sources: [1], [2], [3], [4]"
+      "Sources: [1], [2]"
      ]
     }
    ],
@@ -332,8 +341,7 @@
     "res = query_engine.query(query)\n",
     "\n",
     "# print streamed output chunk by chunk\n",
-    "for chunk in res.response_gen:\n",
-    "    print(chunk.delta or \"\", end=\"\", flush=True)"
+    "res.print_response_stream()"
    ]
   },
   {
@@ -359,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "72832e45",
    "metadata": {},
    "outputs": [
@@ -367,7 +375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sentence embedding is a method of representing words or sentences in a text by encoding their meaning in n-dimensional space. It involves mapping text data into vectors of real numbers, where words or sentences closer in the vector space are more similar. Different types of embeddings exist, such as traditional, static, and contextualized word embeddings, as well as non-parameterized and parameterized models for sentence embeddings. This technique is crucial in preparing texts for machine understanding and various natural language processing tasks.\n"
+      "Sentence embedding is a technique used in natural language processing to represent sentences as vectors in an n-dimensional space. This representation encodes the meaning of the sentence, allowing for the comparison of semantic similarity between sentences. Sentence embeddings are crucial for various applications, such as machine translation, multilingual language models, and cross-lingual retrieval tasks. They enable efficient processing and understanding of text data by machines, facilitating tasks like document classification and sentiment analysis [1], [3], [5].\n"
      ]
     }
    ],
@@ -384,21 +392,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "17020d34-5176-4910-bb88-5c5685513804",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(0, 'http://arxiv.org/pdf/2206.02690v3'),\n",
-       " (1, 'http://arxiv.org/pdf/1904.05542v1'),\n",
-       " (2, 'http://arxiv.org/pdf/2305.15077v2'),\n",
-       " (3, 'http://arxiv.org/pdf/2404.17606v1'),\n",
-       " (4, 'http://arxiv.org/pdf/1910.03375v1')]"
+       "[(0, 'http://arxiv.org/pdf/2205.15744v2'),\n",
+       " (1, 'http://arxiv.org/pdf/2205.15744v2'),\n",
+       " (2, 'http://arxiv.org/pdf/2206.02690v3'),\n",
+       " (3, 'http://arxiv.org/pdf/1904.05542v1'),\n",
+       " (4, 'http://arxiv.org/pdf/1808.05505v3')]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -427,7 +435,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "d32ff2f1-ccd2-4fd0-99df-fd977182df41",
    "metadata": {},
    "outputs": [
@@ -435,7 +443,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Innovations in sentence embedding models include the development of Espresso Sentence Embeddings (ESE) supporting model depth and embedding size scaling [1]. Additionally, there is a shift towards generative models like PromptEOL, which enhance embeddings by introducing an Explicit One word Limitation (EOL) into prompts [2]. Furthermore, research is focusing on computationally efficient direct inference methods for sentence representation, bridging the gap in fine-tuning scenarios [3]. Lastly, advancements like Backward Dependency Enhanced Large Language Models (BeLLM) are exploring the effects of backward dependencies in LLMs for semantic similarity measurements [5].\n"
+      "Recent innovations in sentence embedding models include the development of models like HiT, which learns the hierarchical semantic structure in language models and is trained on WordNet to provide unseen subsumptions and hypernyms for words in sentences. Sentence-BERT and gte-base models have also been recognized for their effectiveness in unsupervised text retrieval tasks. Additionally, there is a focus on improving cross-lingual model alignment by incorporating parallel training datasets, which is particularly beneficial for low-resource languages. These advancements highlight the importance of sentence embedding models in applications such as Bi-text Mining, Information Retrieval, and Retrieval Augmented Generation [1], [2].\n"
      ]
     }
    ],
@@ -452,7 +460,7 @@
     "            \"diversity_bias\": 0.3\n",
     "        },\n",
     "        {\n",
-    "            \"type\": \"udf\",\n",
+    "            \"type\": \"userfn\",\n",
     "            \"user_function\": \"max(0, 5 * get('$.score') - hours(seconds((to_unix_timestamp(now()) - to_unix_timestamp(datetime_parse(get('$.document_metadata.published'), 'yyyy-MM-dd'))))) / 24 / 365)\",\n",
     "            \"limit\": 5\n",
     "        }\n",
@@ -465,21 +473,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "01b96eb2-9e88-4c6a-90c4-676dddcc5ba8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[(0, '2024-02-22'),\n",
-       " (1, '2024-04-05'),\n",
-       " (2, '2024-04-05'),\n",
-       " (3, '2023-11-16'),\n",
-       " (4, '2023-11-09')]"
+       "[(0, '2024-11-25'),\n",
+       " (1, '2024-12-04'),\n",
+       " (2, '2024-11-25'),\n",
+       " (3, '2024-11-25'),\n",
+       " (4, '2024-05-30')]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -514,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "7b0a49d1",
    "metadata": {},
    "outputs": [
@@ -522,7 +530,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sentence embedding is a method used to represent sentences in a text by encoding their meaning into n-dimensional space. This technique involves mapping sentences into vectors of real numbers, where each vector represents the semantic content of a sentence. The proximity of these vectors in the vector space indicates the similarity between the meanings of the sentences. Sentence embeddings are utilized in various machine learning applications to handle and process text data effectively.\n"
+      "Sentence embedding is a technique used in machine learning to represent sentences as vectors in a high-dimensional space. These vectors are designed to capture the semantic meaning of the sentences, allowing machines to understand and process text data more effectively. Sentence embeddings are used in various natural language processing tasks such as machine translation, text classification, and information retrieval. The goal is for sentences with similar meanings to be close to each other in the vector space, despite being composed of different words or structures. This representation facilitates the comparison and manipulation of textual data by algorithms.\n"
      ]
     }
    ],
@@ -555,7 +563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "42af08f5-dc13-4991-96f4-fdd294b0ce97",
    "metadata": {},
    "outputs": [],
@@ -565,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "7e3368be-46a3-4b2f-9589-de3383c65201",
    "metadata": {},
    "outputs": [
@@ -575,15 +583,15 @@
      "text": [
       "Question: What is a sentence embedding model?\n",
       "\n",
-      "Response: A sentence embedding model is a framework that converts sentences into numerical vectors, capturing their semantic meanings. These models, such as Sentence-BERT, SimCSE-BERT, SimCSE-RoBERTa, Sentence-T5, and MP-Net, are used for tasks like information retrieval and semantic textual similarity benchmarks. They play a crucial role in various applications by representing sentences in a continuous vector space for efficient processing and analysis.\n",
+      "Response: A sentence embedding model is a type of model that represents a given input sentence as a fixed-dimensional vector, regardless of the sentence's length. These embeddings are particularly useful in various natural language processing (NLP) tasks, such as information retrieval, question answering, and machine translation. Sentence embeddings have shown significant improvements in performance for these tasks compared to static word embeddings, which typically have fewer dimensions [4].\n",
       "\n",
       "Question: What are some known models?\n",
       "\n",
-      "Response: Some known sentence embedding models include Sentence-BERT, SimCSE-BERT, SimCSE-RoBERTa, Sentence-T5, MP-Net, GenSen, and DSE. These models have been used for various tasks such as embedding inversion attacks and semantic textual similarity benchmarks. Additionally, there is ongoing research and development in this area, with a focus on both supervised and unsupervised models for constructing sentence embeddings.\n",
+      "Response: Some known sentence embedding models include HiT, Sentence-BERT, and gte-base, which are effective in unsupervised text retrieval tasks [1]. Other models include GenSen and DSE, which have been compared across different test sets [4]. Additionally, InferSent, with its two versions based on GloVe and fastText word embeddings, and the Universal Sentence Encoder (USE), which comes in versions based on Deep Average Networks and Transformer networks, are also well-known sentence embedding models [7].\n",
       "\n",
       "Question: How are they different than token embedding models\n",
       "\n",
-      "Response: Sentence embedding models differ from token embedding models in that sentence embedding models focus on capturing the overall meaning and context of a sentence as a whole, while token embedding models concentrate on representing individual words or tokens within a sentence. Sentence embedding models excel at detecting meaning equivalence but may struggle with distinguishing fine-grained degrees of meaning overlap. On the other hand, token embedding models, such as those using token-embedding pooling techniques, show minimal correlation with models fine-tuned for sentence similarity.\n",
+      "Response: Sentence embedding models and token embedding models differ primarily in their focus and application. Sentence embedding models aim to generate a single vector representation for an entire sentence, capturing its overall meaning. This is often achieved by pooling word or token embeddings, such as averaging them, and then fine-tuning the resulting representation for specific tasks or general purposes [1]. In contrast, token embedding models focus on representing individual words or tokens within a sentence, often used in tasks that require understanding the role of each word in context, such as translation language modeling [2]. Sentence embeddings are typically used for tasks like semantic textual similarity, where the goal is to compare the meanings of entire sentences [6].\n",
       "\n"
      ]
     }
@@ -611,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "c8b24622-bc73-4bee-929e-377f06335a80",
    "metadata": {},
    "outputs": [],
@@ -621,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "c8f16016-be7c-411f-aafd-b03d8816d21d",
    "metadata": {},
    "outputs": [
@@ -629,14 +637,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The individuals behind SBERT are Reimers and Gurevych, as they proposed the SBERT network structure in 2019. SBERT is based on transformer models like BERT and fine-tunes them using a siamese network structure [1]."
+      "SBERT, or Sentence-BERT, was developed by Nils Reimers and Iryna Gurevych in 2019. It is based on transformer models like BERT, which was introduced by Devlin et al. in 2018, and fine-tunes these models using a siamese network structure to create sentence embeddings efficiently [3]."
      ]
     }
    ],
    "source": [
     "response = ce.stream_chat(\"Who is behind SBERT?\")\n",
-    "for chunk in response.chat_stream:\n",
-    "    print(chunk.delta or \"\", end=\"\", flush=True)"
+    "response.print_response_stream()"
    ]
   },
   {
@@ -659,7 +666,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "648b415f-303a-4d0a-aef1-9d58aa6380ab",
    "metadata": {},
    "outputs": [],
@@ -669,7 +676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "c77fd093-522d-435e-954e-f571a16a64bd",
    "metadata": {},
    "outputs": [
@@ -677,35 +684,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Initializing vectara-agentic version 0.1.17...\n",
-      "No observer set.\n",
-      "> Running step 36031c69-ab3e-4952-8e6b-d07b4310a628. Step input: Tell me about the latest innovations in sentence embedding models.\n",
+      "Failed to set up observer (No module named 'phoenix.otel'), ignoring\n",
+      "> Running step d739bbed-4386-4da0-91ba-7fbe877e38b2. Step input: Tell me about the latest innovations in sentence embedding models.\n",
       "\u001b[1;3;38;5;200mThought: The current language of the user is: English. I need to use a tool to help me answer the question.\n",
       "Action: ask_embeddings\n",
       "Action Input: {'query': 'latest innovations in sentence embedding models'}\n",
       "\u001b[0m\u001b[1;3;34mObservation: \n",
-      "                    Response: '''The latest innovations in sentence embedding models include Sentence-BERT, SimCSE-BERT/SimCSE-RoBERTa, Sentence-T5, and MP-Net [1]. These models have been found to have isotropy issues, which can lead to alignment problems in areas such as domain adaptation, word embedding evaluation, and machine translation [2]. Additionally, there are concerns about the trustworthiness of reported results in the field of NLP, with some studies suggesting that neural language models have been misleadingly evaluated [5]. A novel sentence embedding model called Espresso Sentence Embeddings (ESE) has been proposed, which supports both model depth and embedding size scaling [4]. This model aims to address the limitations of existing sentence embedding models and provide a more effective and trustworthy approach.'''\n",
+      "                    Response: '''The latest innovations in sentence embedding models include HiT, Sentence-BERT, and gte-base models, which have achieved notable breakthroughs in fine-tuning scenarios [2]. However, there is a research gap in computationally efficient direct inference methods for sentence representation [1]. Recent studies have shown that sentence embedding models with both lower alignment and uniformity achieve better performance in general [3]. Additionally, contrastive learning has been applied to sentence embedding models, leading to performance improvements, as demonstrated in Japanese language models [5]. Furthermore, the use of large language models such as LLaMA and Mistral has also contributed to advancements in sentence embedding [1].'''\n",
       "                    References:\n",
-      "                    [1]: page='5'; section='75'; PTEX.Fullbanner='This is pdfTeX, Version 3.14159265-2.6-1.40.21 (TeX Live 2020) kpathsea version 6.3.2'; CreationDate='D:20230505003815Z'; Keywords=''; Producer='pdfTeX-1.40.21'; Author=''; Title=''; Creator='LaTeX with hyperref'; ModDate='D:20230505003815Z'; Trapped='/False'; Subject=''; url='http://arxiv.org/pdf/2305.03010v1'; title='arXiv:2305.03010v1  [cs.CL]  4 May 2023'; author='Haoran Li'; published='2023-05-04'; framework='llama_index'.\n",
-      "[2]: page='11'; title='Extracting Sentence Embeddings from Pretrained Transformer Models'; breadcrumb='[\"Related work\",\"Reshaping representation spaces\"]'; section='4'; PTEX.Fullbanner='This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) kpathsea version 6.3.5'; CreationDate='D:20240816002943Z'; Keywords='BERT; embeddings; large language models; natural language processing; text embeddings; sentence vector representation; semantic similarity; transformer models; prompt engineering; unsupervised learning'; Producer='pdfTeX-1.40.25'; Author='Lukas Stankevicius and Mantas Lukosevicius'; Title='Extracting Sentence Embeddings from Pretrained Transformer Models'; Creator='LaTeX with hyperref'; ModDate='D:20240816002943Z'; Trapped='/False'; Subject=''; url='http://arxiv.org/pdf/2408.08073v1'; author='Lukas Stankevičius'; published='2024-08-15'; framework='llama_index'.\n",
-      "[4]: page='10'; title='Introduction'; section='14'; PTEX.Fullbanner='This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) kpathsea version 6.3.5'; CreationDate='D:20240522002303Z'; Keywords=''; Producer='pdfTeX-1.40.25'; Author=''; Title=''; Creator='LaTeX with hyperref'; ModDate='D:20240522002303Z'; Trapped='/False'; Subject=''; url='http://arxiv.org/pdf/2402.14776v2'; author='Xianming Li'; published='2024-02-22'; framework='llama_index'.\n",
-      "[5]: page='1'; section='6'; PTEX.Fullbanner='This is pdfTeX, Version 3.14159265-2.6-1.40.17 (TeX Live 2016) kpathsea version 6.2.2'; CreationDate='D:20190605010437Z'; Keywords=''; Producer='pdfTeX-1.40.17'; Author=''; Title=''; Creator='LaTeX with hyperref package'; ModDate='D:20190605010437Z'; Trapped='/False'; Subject=''; url='http://arxiv.org/pdf/1906.01575v1'; title='arXiv:1906.01575v1  [cs.CL]  4 Jun 2019'; author='Steffen Eger'; published='2019-06-04'; framework='llama_index'.\n",
+      "                    [1]: PTEX.Fullbanner='This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) kpathsea version 6.3.5'; CreationDate='D:20240516003614Z'; Keywords=''; Producer='pdfTeX-1.40.25'; Author=''; Title=''; Creator='LaTeX with hyperref'; ModDate='D:20240516003614Z'; Trapped='/False'; Subject=''; url='http://arxiv.org/pdf/2404.03921v2'; title='Simple Techniques for Enhancing Sentence Embeddings in Generative Language Models'; author='Bowen Zhang'; published='2024-04-05'; framework='llama_index'.\n",
+      "[2]: PTEX.Fullbanner='This is pdfTeX, Version 3.141592653-2.6-1.40.25 (TeX Live 2023) kpathsea version 6.3.5'; CreationDate='D:20241126022050Z'; Keywords=''; Producer='pdfTeX-1.40.25'; Author=''; Title=''; Creator='LaTeX with hyperref'; ModDate='D:20241126022050Z'; Trapped='/False'; Subject=''; url='http://arxiv.org/pdf/2411.16236v1'; title='Introduction'; author='Hong Liu'; published='2024-11-25'; framework='llama_index'.\n",
+      "[3]: PTEX.Fullbanner='This is pdfTeX, Version 3.14159265-2.6-1.40.21 (TeX Live 2020) kpathsea version 6.3.2'; CreationDate='D:20220426000538Z'; Keywords=''; Producer='pdfTeX-1.40.21'; Author=''; Title=''; Creator='LaTeX with hyperref'; ModDate='D:20220426000538Z'; Trapped='/False'; Subject=''; url='http://arxiv.org/pdf/2204.10931v1'; title='arXiv:2204.10931v1  [cs.CL]  22 Apr 2022'; author='Miaoran Zhang'; published='2022-04-22'; framework='llama_index'.\n",
+      "[5]: PTEX.Fullbanner='This is pdfTeX, Version 3.14159265-2.6-1.40.21 (TeX Live 2020) kpathsea version 6.3.2'; CreationDate='D:20230120013023Z'; Keywords=''; Producer='pdfTeX-1.40.21'; Author='Zihao Chen; Hisashi Handa; Kimiaki Shirahama; '; Title='JCSE: Contrastive Learning of Japanese Sentence Embeddings and Its Applications'; Creator='LaTeX with hyperref'; ModDate='D:20230120013023Z'; Trapped='/False'; Subject=''; url='http://arxiv.org/pdf/2301.08193v1'; title='JCSE: Contrastive Learning of Japanese Sentence Embeddings and Its Applications'; author='Zihao Chen'; published='2023-01-19'; framework='llama_index'.\n",
       "\n",
       "                \n",
-      "\u001b[0m> Running step 93455a6a-c4ea-46c0-9098-a1f5a6d4831d. Step input: None\n",
+      "\u001b[0m> Running step 22bc039e-1a53-451f-9c21-0f8faa0aea00. Step input: None\n",
       "\u001b[1;3;38;5;200mThought: I can answer without using any more tools. I'll use the user's language to answer\n",
-      "Answer: Recent innovations in sentence embedding models include advancements such as Sentence-BERT, SimCSE-BERT/SimCSE-RoBERTa, Sentence-T5, and MP-Net. These models have been noted for having isotropy issues, which can cause alignment problems in various applications like domain adaptation and machine translation. Additionally, there are concerns about the reliability of reported results in NLP, with some studies indicating that neural language models might have been misleadingly evaluated. A new model called Espresso Sentence Embeddings (ESE) has been introduced, which supports scaling in both model depth and embedding size, aiming to address the limitations of existing models and provide a more effective and trustworthy approach. \n",
-      "\n",
-      "For more detailed information, you can refer to the following sources: [arXiv:2305.03010v1](http://arxiv.org/pdf/2305.03010v1), [arXiv:2408.08073v1](http://arxiv.org/pdf/2408.08073v1), and [arXiv:2402.14776v2](http://arxiv.org/pdf/2402.14776v2).\n",
-      "\u001b[0mTime taken: 12.116064071655273\n"
+      "Answer: Recent innovations in sentence embedding models include the development of models like HiT, Sentence-BERT, and gte-base, which have made significant advancements in fine-tuning scenarios. However, there is still a need for more computationally efficient direct inference methods for sentence representation. Studies have shown that models with lower alignment and uniformity tend to perform better. Additionally, contrastive learning has been applied to improve performance, as seen in Japanese language models. The use of large language models such as LLaMA and Mistral has also contributed to advancements in this field. For more details, you can refer to the following sources: [1](http://arxiv.org/pdf/2404.03921v2), [2](http://arxiv.org/pdf/2411.16236v1), [3](http://arxiv.org/pdf/2204.10931v1), and [5](http://arxiv.org/pdf/2301.08193v1).\n",
+      "\u001b[0mTime taken: 12.01492714881897\n"
      ]
     },
     {
      "data": {
       "text/markdown": [
-       "Recent innovations in sentence embedding models include advancements such as Sentence-BERT, SimCSE-BERT/SimCSE-RoBERTa, Sentence-T5, and MP-Net. These models have been noted for having isotropy issues, which can cause alignment problems in various applications like domain adaptation and machine translation. Additionally, there are concerns about the reliability of reported results in NLP, with some studies indicating that neural language models might have been misleadingly evaluated. A new model called Espresso Sentence Embeddings (ESE) has been introduced, which supports scaling in both model depth and embedding size, aiming to address the limitations of existing models and provide a more effective and trustworthy approach. \n",
-       "\n",
-       "For more detailed information, you can refer to the following sources: [arXiv:2305.03010v1](http://arxiv.org/pdf/2305.03010v1), [arXiv:2408.08073v1](http://arxiv.org/pdf/2408.08073v1), and [arXiv:2402.14776v2](http://arxiv.org/pdf/2402.14776v2)."
+       "Recent innovations in sentence embedding models include the development of models like HiT, Sentence-BERT, and gte-base, which have made significant advancements in fine-tuning scenarios. However, there is still a need for more computationally efficient direct inference methods for sentence representation. Studies have shown that models with lower alignment and uniformity tend to perform better. Additionally, contrastive learning has been applied to improve performance, as seen in Japanese language models. The use of large language models such as LLaMA and Mistral has also contributed to advancements in this field. For more details, you can refer to the following sources: [1](http://arxiv.org/pdf/2404.03921v2), [2](http://arxiv.org/pdf/2411.16236v1), [3](http://arxiv.org/pdf/2204.10931v1), and [5](http://arxiv.org/pdf/2301.08193v1)."
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -767,7 +769,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I updated the LlamaIndex integration notebook for the latest update on Vectara managed index (version 0.4.0), including a message indicating the change at the top of the notebook and explaining some new features/parameters (e.g. `chunking_strategy` for the `insert_file()` function). 